### PR TITLE
add description about docs-ja github repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,13 @@
+Flask - docs-ja repository
+==========================
+
+This repository is forked from original one in order to set up the work
+environment for privatelly translating the docs into Japanese.
+
+The following content is the original README.rst file.
+
+-----
+
 Flask
 =====
 


### PR DESCRIPTION
Update README.rst to notice this branch is forked for docs translation even on the top page of this  repository in GitHub.